### PR TITLE
브랜치 생성 및 푸시 작업 시 403 권한 오류 해결

### DIFF
--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -1,4 +1,8 @@
 name: Create Jira issue
+
+permissions:
+  contents: write
+
 on:
   issues:
     types:


### PR DESCRIPTION
- 브랜치 생성 및 푸시 작업 시 403 권한 오류 해결