### PR TITLE
[ feat(community) ] : 커뮤니티 목록 페이징 및 CRUD 연동 — DTO/서비스/컨트롤러/보안 설정 포함

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
-src
 src/main/resources/application.yml
 src/main/resources/application-docker.yml
 docker-compose.yml

--- a/src/main/java/com/talkit/app/domain/community/controller/CommunityController.java
+++ b/src/main/java/com/talkit/app/domain/community/controller/CommunityController.java
@@ -1,11 +1,14 @@
 package com.talkit.app.domain.community.controller;
 
+import com.talkit.app.domain.community.dto.CommunityListResponseDto;
 import com.talkit.app.domain.community.dto.CommunityRequestDto;
 import com.talkit.app.domain.community.dto.CommunityResponseDto;
 import com.talkit.app.domain.community.service.CommunityService;
 import com.talkit.app.global.auth.AuthenticatedUser;
 import com.talkit.app.global.auth.AuthenticationHolder;
 import com.talkit.app.global.dto.ResponseDto;
+import com.talkit.app.global.page.dto.PageRequestVO;
+import com.talkit.app.global.page.dto.PageResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -20,14 +23,45 @@ public class CommunityController {
 
     private final CommunityService communityService;
 
+    @Operation(summary = "게시물 단일 조회")
+    @GetMapping("/{id}")
+    public ResponseDto<CommunityResponseDto> getCommunityById(@PathVariable Long id) {
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityService.getCommunityById(id, userId));
+    }
+
+    @Operation(summary = "게시물 목록 조회")
+    @GetMapping("/list")
+    public ResponseDto<PageResponseDto<CommunityListResponseDto>> list(PageRequestVO pageRequestVO) {
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityService.pagesByCommunity(userId, pageRequestVO));
+    }
+
+    @Operation(summary = "수정 페이지용 게시물 조회")
+    @AuthenticatedUser
+    @GetMapping("/edit/{id}")
+    public ResponseDto<CommunityResponseDto> getPostForEdit(@PathVariable Long id) {
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityService.getPostForEdit(id, userId), "게시물을 성공적으로 가져왔습니다.");
+    }
+
     @Operation(summary = "게시물 작성")
     @AuthenticatedUser
     @PostMapping("/create")
-    public ResponseDto<CommunityResponseDto> communityCreate(
-        @RequestBody @Valid CommunityRequestDto requestDto
-    ) {
+    public ResponseDto<CommunityResponseDto> communityCreate(@RequestBody @Valid CommunityRequestDto requestDto) {
         Long userId = AuthenticationHolder.getCurrentUserId();
         return ResponseDto.of(communityService.createCommunity(requestDto, userId), "게시물이 성공적으로 생성되었습니다.");
+    }
+
+    @Operation(summary = "게시물 수정")
+    @AuthenticatedUser
+    @PutMapping("/{id}")
+    public ResponseDto<CommunityResponseDto> update(
+        @RequestBody @Valid CommunityRequestDto requestDto,
+        @PathVariable("id") Long communityId) {
+
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityService.updateCommunity(communityId, requestDto, userId), "게시물이 성공적으로 수정되었습니다.");
     }
 
 }

--- a/src/main/java/com/talkit/app/domain/community/dto/CommunityListResponseDto.java
+++ b/src/main/java/com/talkit/app/domain/community/dto/CommunityListResponseDto.java
@@ -1,0 +1,56 @@
+package com.talkit.app.domain.community.dto;
+
+import com.talkit.app.domain.community.entity.Community;
+import com.talkit.app.domain.like.entity.CommunityLike;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record CommunityListResponseDto(
+    String id,
+    String title,
+    String content,
+    String category,
+    String nickname,
+    int likeCount,
+    int commentCount,
+    boolean isLiked
+) {
+
+    public static CommunityListResponseDto from(Community community) {
+
+        return CommunityListResponseDto.builder()
+            .id(community.getId().toString())
+            .title(community.getTitle())
+            .content(getPreviewContent(community.getContent(), 250))
+            .nickname(community.getUser().getNickname())
+            .category(community.getCategory())
+            .build();
+    }
+
+    public static CommunityListResponseDto of(Community community,
+        int likeCount,
+        int commentCount,
+        List<CommunityLike> communityLikesByUserId) {
+
+        return CommunityListResponseDto.builder()
+            .id(community.getId().toString())
+            .title(community.getTitle())
+            .category(community.getCategory())
+            .likeCount(likeCount)
+            .nickname(community.getUser().getNickname())
+            .commentCount(commentCount)
+            .isLiked(communityLikesByUserId.stream()
+                .anyMatch(communityLike -> community.getId().equals(communityLike.getCommunity().getId())))
+            .content(getPreviewContent(community.getContent(), 150))
+            .build();
+    }
+
+    private static String getPreviewContent(String content, int maxLength) {
+        if (content.length() > maxLength) {
+            return content.substring(0, maxLength);
+        }
+        return content;
+    }
+}
+

--- a/src/main/java/com/talkit/app/domain/community/dto/CommunityResponseDto.java
+++ b/src/main/java/com/talkit/app/domain/community/dto/CommunityResponseDto.java
@@ -23,6 +23,7 @@ public record CommunityResponseDto(
             .id(community.getId())
             .title(community.getTitle())
             .content(community.getContent())
+            .category(community.getCategory())
             .nickname(community.getUser().getNickname())
             .isOwnedByUser(community.getUser().getId().equals(userId))
             .createdAt(community.getCreatedAt())

--- a/src/main/java/com/talkit/app/domain/community/entity/Community.java
+++ b/src/main/java/com/talkit/app/domain/community/entity/Community.java
@@ -62,9 +62,10 @@ public class Community extends BaseEntity {
             .build();
     }
 
-    public void update(String title, String content) {
+    public void update(String title, String content, String category) {
         this.title = title;
         this.content = content;
+        this.category = category;
     }
 
 }

--- a/src/main/java/com/talkit/app/domain/community/repository/CommunityCommentRepository.java
+++ b/src/main/java/com/talkit/app/domain/community/repository/CommunityCommentRepository.java
@@ -1,10 +1,19 @@
 package com.talkit.app.domain.community.repository;
 
 import com.talkit.app.domain.community.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommunityCommentRepository extends JpaRepository<Comment, Long> {
+
+    @Query("SELECT cc FROM Comment cc JOIN cc.community c WHERE c.id = :communityId ORDER BY cc.updatedAt DESC")
+    Page<Comment> findByCommunityId(@Param("communityId") Long communityId, Pageable pageable);
+
+    int countByCommunityId(Long communityId);
 
 }

--- a/src/main/java/com/talkit/app/domain/community/repository/CommunityRepository.java
+++ b/src/main/java/com/talkit/app/domain/community/repository/CommunityRepository.java
@@ -1,10 +1,27 @@
 package com.talkit.app.domain.community.repository;
 
 import com.talkit.app.domain.community.entity.Community;
+import com.talkit.app.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommunityRepository extends JpaRepository<Community, Long> {
+
+    @Query("SELECT c FROM Community c ORDER BY c.createdAt DESC")
+    Page<Community> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    default Page<Community> findByIsPublicTrueOrUserId(Long userId, Pageable pageable) {
+        return findAllByOrderByCreatedAtDesc(pageable);
+    }
+
+    @Query("SELECT c FROM Community c WHERE c.user.id = :userId ORDER BY c.createdAt DESC")
+    Page<Community> findByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    int countByUser(User user);
 
 }

--- a/src/main/java/com/talkit/app/domain/community/service/CommunityService.java
+++ b/src/main/java/com/talkit/app/domain/community/service/CommunityService.java
@@ -1,13 +1,23 @@
 package com.talkit.app.domain.community.service;
 
+import static com.talkit.app.global.exception.ExceptionType.NOT_FOUND_COMMUNITY;
 import static com.talkit.app.global.exception.ExceptionType.NOT_FOUND_USER;
+import static com.talkit.app.global.exception.ExceptionType.UNAUTHORIZED_NO_AUTHENTICATION_CONTEXT;
 
+import com.talkit.app.domain.community.dto.CommunityListResponseDto;
 import com.talkit.app.domain.community.dto.CommunityRequestDto;
 import com.talkit.app.domain.community.dto.CommunityResponseDto;
 import com.talkit.app.domain.community.entity.Community;
+import com.talkit.app.domain.community.repository.CommunityCommentRepository;
 import com.talkit.app.domain.community.repository.CommunityRepository;
+import com.talkit.app.domain.like.entity.CommunityLike;
+import com.talkit.app.domain.like.repository.CommunityLikeRepository;
 import com.talkit.app.domain.user.entity.User;
 import com.talkit.app.domain.user.repository.UserRepository;
+import com.talkit.app.global.page.dto.PageRequestVO;
+import com.talkit.app.global.page.dto.PageResponseDto;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +28,27 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommunityService {
 
     private final CommunityRepository communityRepository;
+    private final CommunityLikeRepository communityLikeRepository;
+    private final CommunityCommentRepository communityCommentRepository;
     private final UserRepository userRepository;
+
+    public CommunityResponseDto getCommunityById(Long id, Long userId) {
+        Community community = getCommunity(id);
+
+        return CommunityResponseDto.of(community, userId);
+    }
+
+    public PageResponseDto<CommunityListResponseDto> pagesByCommunity(Long userId, PageRequestVO pageRequestVO) {
+        List<CommunityLike> communityLikes = getCommunityLikesBy(userId);
+
+        return PageResponseDto.of((communityRepository.findAllByOrderByCreatedAtDesc(pageRequestVO.toPageable()))
+            .map(community -> {
+                int likeCount = communityLikeRepository.countByCommunityId(community.getId());
+                int commentCount = communityCommentRepository.countByCommunityId(community.getId());
+                return CommunityListResponseDto.of(community, likeCount, commentCount, communityLikes);
+            })
+        );
+    }
 
     @Transactional
     public CommunityResponseDto createCommunity(CommunityRequestDto requestDto, Long userId) {
@@ -40,6 +70,45 @@ public class CommunityService {
 
         communityRepository.save(community);
         return CommunityResponseDto.of(community, userId);
+    }
+
+
+    @Transactional
+    public CommunityResponseDto updateCommunity(Long id, CommunityRequestDto requestDto, Long userId) {
+        Community community = getCommunity(id);
+        validateOwnership(community, userId);
+
+        community.update(
+            requestDto.title(),
+            requestDto.content(),
+            requestDto.category()
+        );
+
+        return CommunityResponseDto.of(community, userId);
+    }
+
+    public CommunityResponseDto getPostForEdit(Long id, Long userId) {
+        Community community = getCommunity(id);
+        validateOwnership(community, userId);
+
+        return CommunityResponseDto.of(community, userId);
+    }
+
+    private Community getCommunity(Long id) {
+        return communityRepository.findById(id)
+            .orElseThrow(NOT_FOUND_COMMUNITY::of);
+    }
+
+    private void validateOwnership(Community community, Long userId) {
+        if (!community.getUser().getId().equals(userId)) {
+            throw UNAUTHORIZED_NO_AUTHENTICATION_CONTEXT.of("게시물을 수정/삭제할 권한이 없습니다.");
+        }
+    }
+
+    private List<CommunityLike> getCommunityLikesBy(Long userId) {
+        return userId.equals(User.ANONYMOUS_USER_ID)
+            ? new ArrayList<>()
+            : communityLikeRepository.findCommunityLikesByUserId(userId);
     }
 
 }

--- a/src/main/java/com/talkit/app/domain/like/repository/CommunityLikeRepository.java
+++ b/src/main/java/com/talkit/app/domain/like/repository/CommunityLikeRepository.java
@@ -1,9 +1,23 @@
 package com.talkit.app.domain.like.repository;
 
+import com.talkit.app.domain.community.entity.Community;
 import com.talkit.app.domain.like.entity.CommunityLike;
+import com.talkit.app.domain.user.entity.User;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommunityLikeRepository extends JpaRepository<CommunityLike, Long> {
+
+    Optional<CommunityLike> findByUserAndCommunity(User user, Community community);
+
+    @Query("SELECT clike FROM CommunityLike clike WHERE clike.user.id = :userId AND clike.community.id = :communityId")
+    Optional<CommunityLike> findByUserIdAndCommunityId(@Param("userId") Long userId, @Param("communityId") Long communityId);
+
+    List<CommunityLike> findCommunityLikesByUserId(Long userId);
+    int countByCommunityId(Long communityId);
 }

--- a/src/main/java/com/talkit/app/global/config/SecurityConfig.java
+++ b/src/main/java/com/talkit/app/global/config/SecurityConfig.java
@@ -77,8 +77,10 @@ public class SecurityConfig {
                 .requestMatchers(WHITE_LIST).permitAll()
                 .requestMatchers(WHITE_LIST_COMMUNITY).permitAll()
                 .requestMatchers(
-                    "/api/community/{id}/comment/**",
-                    "/api/community/{id}/like/**",
+                    "/api/community/create",      // 게시글 작성
+                    "/api/community/{id}/like/**", // 좋아요
+                    "/api/community/{id}/comment/**", // 댓글 작성
+                    "/api/community/edit/**",      // 수정 페이지 조회
                     "/api/auth/status",
                     "/api/auth/user"
                 ).hasAuthority("ROLE_USER")

--- a/src/main/java/com/talkit/app/global/exception/ExceptionType.java
+++ b/src/main/java/com/talkit/app/global/exception/ExceptionType.java
@@ -21,6 +21,7 @@ public enum ExceptionType {
     // 토큰 유효성 실패
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED,  "Access Token이 유효하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED,  "Refresh Token이 유효하지 않습니다."),
+    UNAUTHORIZED_NO_AUTHENTICATION_CONTEXT(HttpStatus.UNAUTHORIZED, "인증 정보가 존재하지 않습니다."),
 
 
     // Forbidden(403)
@@ -28,9 +29,9 @@ public enum ExceptionType {
     // NOT_FOUND(404)
     //NOT_FOUND(HttpStatus.NOT_FOUND, "데이터가 존재하지 않음"),
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
+    NOT_FOUND_COMMUNITY(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다."),
     //NOT_FOUND_RECIPE_FAVORITE(HttpStatus.NOT_FOUND, "즐겨찾기한 레시피가 없습니다."),
     //NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
-   // NOT_FOUND_COMMUNITY(HttpStatus.NOT_FOUND, "게시물을 찾을 수 없습니다."),
 
     // Internal Server Error(500)
     //SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러"),

--- a/src/main/java/com/talkit/app/global/page/dto/PageRequestVO.java
+++ b/src/main/java/com/talkit/app/global/page/dto/PageRequestVO.java
@@ -1,0 +1,38 @@
+package com.talkit.app.global.page.dto;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+public record PageRequestVO(int pageNo, int pageSize) {
+    private static final int DEFAULT_PAGE_NO = 1;
+    private static final int DEFAULT_PAGE_SIZE = 12;
+    private static final int MAX_PAGE_SIZE = 30;
+
+    public PageRequestVO(int pageNo, int pageSize) {
+        this.pageNo = validatePageNo(pageNo);
+        this.pageSize = validatePageSize(pageSize);
+    }
+
+    public static PageRequestVO of(Integer pageNo, Integer pageSize) {
+        return new PageRequestVO(
+            Optional.ofNullable(pageNo).orElse(DEFAULT_PAGE_NO),
+            Optional.ofNullable(pageSize).map(PageRequestVO::validatePageSize).orElse(DEFAULT_PAGE_SIZE)
+        );
+    }
+
+    public Pageable toPageable() {
+        return PageRequest.of(pageNo - 1, pageSize);
+    }
+
+    private static int validatePageNo(int pageNo) {
+        return pageNo >= 1 ? pageNo : DEFAULT_PAGE_NO;
+    }
+
+    private static int validatePageSize(int pageSize) {
+        if (pageSize < 1) return DEFAULT_PAGE_SIZE;
+        if (pageSize > MAX_PAGE_SIZE) return MAX_PAGE_SIZE;
+        return pageSize;
+    }
+}

--- a/src/main/java/com/talkit/app/global/page/dto/PageResponseDto.java
+++ b/src/main/java/com/talkit/app/global/page/dto/PageResponseDto.java
@@ -1,0 +1,31 @@
+package com.talkit.app.global.page.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PageResponseDto<T> {
+    private List<T> content;
+    private int currentPage;
+    private int totalPages;
+    private long totalItems;
+    private boolean isLast;
+
+    public static <T> PageResponseDto<T> of(Page<T> page) {
+        return new PageResponseDto<>(
+            page.getContent(),
+            page.getNumber(),
+            page.getTotalPages(),
+            page.getTotalElements(),
+            page.isLast()
+        );
+    }
+}
+


### PR DESCRIPTION
## 상세 설명 요약
- 커뮤니티 기능에 페이징 기반 목록 및 CRUD(생성/수정/조회) 연동을 추가
- 주요 변경에는 페이징 DTO, 커뮤니티 엔티티/레포지토리, 리스트/상세 응답 DTO, 서비스/컨트롤러 구현
-  관련 시큐리티 설정 반영이 포함

## 주요 변경사항
- chore(gitignore): .gitignore에서 src 무시 규칙 제거 — 신규 DTO 추가 허용
- feat(paging): PageRequestVO, PageResponseDto 추가 — 기본 페이징 요청/응답 DTO
- chore(exception): NOT_FOUND_COMMUNITY 등 예외 타입 추가
- feat(community): Community 엔티티 및 관련 레포지토리 추가/수정
   -  엔티티: user, title, content, category, 댓글/좋아요 연관 설정
   - 레포: 페이징 조회, 사용자별 조회 및 카운트 메서드 추가 
- feat(community): CommunityListResponseDto 추가 — 리스트 응답 포맷 및 content 미리보기 로직
- feat(community): CommunityResponseDto 수정 — 소유자 판정(isOwnedByUser), 타임스탬프 등 포함
- feat(community): CommunityService 구현 — 목록 페이징, 생성, 수정, 편집용 조회, 소유권 검증
   - 현재 likeCount/commentCount는 개별 카운트 쿼리로 계산 (추후에 성능 리팩토링 필요) 
- feat(community): CommunityController 구현 — 목록/상세/작성/수정/편집용 엔드포인트 추가
- feat(security): SecurityConfig에 커뮤니티 관련 권한·화이트리스트 및 CORS 설정 반영


## 프론트 연동 포인트(이번 변경으로 추가/수정된 API)
- 목록 조회: **GET** /api/community/list?pageNo={pageNo}&pageSize={pageSize}
- 상세 조회: **GET** /api/community/{id}
- 수정용 데이터 조회(**로그인 필요**): **GET** /api/community/edit/{id}
- 게시물 작성(**로그인 필요**): **POST** /api/community/create
- 게시물 수정(**작성자만 가능**): **PUT** /api/community/{id}
- 
- 페이징 파라미터: pageNo(기본값 1), pageSize(기본값 12) 
   -  API 소비자(프론트)에 전달되는 페이지 번호 형식 확인 필요(현재 내부 변환 로직 확인 권장
- DTO 변경: CommunityListResponseDto, CommunityResponseDto가 프론트 표준에 맞는지 확인 필요
   - 특히 id 타입 및 content preview 길이

<img width="100%" height="100%" alt="image" src="https://github.com/user-attachments/assets/f70c3a05-c6d3-4505-ba15-c21af979ecc2" />
<img width="100%" height="100%" alt="image" src="https://github.com/user-attachments/assets/e35e9fea-5246-4d69-9c1f-dd67e687045b" />


