### PR TITLE
[ feat ] : 비밀번호 확인 및 변경 기능 구현

### DIFF
--- a/src/main/java/com/talkit/app/domain/user/controller/UserAuthController.java
+++ b/src/main/java/com/talkit/app/domain/user/controller/UserAuthController.java
@@ -18,7 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
-@Tag(name = "회원가입 및 로그인/로그아웃", description = "회원가입 및 로그인/로그아웃 관련 API")
+@Tag(name = "회원가입 및 로그인/로그아웃", description = "회원가입 및 로그인/로그아웃 및 프로필 수정 관련 API")
 @RestController
 @RequestMapping("/api/users")
 public class UserAuthController {
@@ -56,12 +56,33 @@ public class UserAuthController {
     }
 
     @Operation(summary = "닉네임 수정")
-    @AuthenticatedUser // 커뮤니티 컨트롤러처럼 인증 어노테이션 추가
+    @AuthenticatedUser
     @PatchMapping("/nickname")
     public ResponseDto<String> updateNickname(@RequestBody UserRequestDto.UpdateNickname request) {
         Long userId = AuthenticationHolder.getCurrentUserId();
         String updatedNickname = userService.updateNickname(userId, request);
 
         return ResponseDto.of(updatedNickname, "닉네임이 성공적으로 수정되었습니다.");
+    }
+
+    @Operation(summary = "현재 비밀번호 확인 (변경 전 검증)")
+    @AuthenticatedUser
+    @PostMapping("/verify-password")
+    public ResponseDto<Boolean> verifyPassword(@RequestBody Map<String, String> request) {
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        String currentPassword = request.get("currentPassword");
+        userService.verifyPassword(userId, currentPassword);
+
+        return ResponseDto.of(true, "비밀번호가 일치합니다.");
+    }
+
+    @Operation(summary = "비밀번호 변경")
+    @AuthenticatedUser
+    @PatchMapping("/update-password")
+    public ResponseDto<Void> updatePassword(@RequestBody UserRequestDto.UpdatePassword request) {
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        userService.updatePassword(userId, request);
+
+        return ResponseDto.of(null, "비밀번호가 성공적으로 변경되었습니다.");
     }
 }

--- a/src/main/java/com/talkit/app/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/talkit/app/domain/user/dto/UserRequestDto.java
@@ -2,6 +2,7 @@ package com.talkit.app.domain.user.dto;
 
 import lombok.Getter;
 
+@Getter
 public class UserRequestDto {
 
     @Getter
@@ -22,5 +23,19 @@ public class UserRequestDto {
     @Getter
     public static class UpdateNickname {
         private String nickname;
+    }
+
+    @Getter
+    public static class UpdatePassword {
+        private String currentPassword;
+        private String newPassword;
+
+        public String getCurrentPassword() {
+            return currentPassword;
+        }
+
+        public String getNewPassword() {
+            return newPassword;
+        }
     }
 }

--- a/src/main/java/com/talkit/app/domain/user/entity/User.java
+++ b/src/main/java/com/talkit/app/domain/user/entity/User.java
@@ -77,4 +77,8 @@ public class User extends BaseEntity {
         }
         this.nickname = newNickname;
     }
+
+    public void changePassword(String encodedPassword) {
+        this.password = encodedPassword;
+    }
 }

--- a/src/main/java/com/talkit/app/domain/user/service/UserService.java
+++ b/src/main/java/com/talkit/app/domain/user/service/UserService.java
@@ -55,9 +55,29 @@ public class UserService {
         return user.getNickname();
     }
 
+    @Transactional(readOnly = true)
+    public void verifyPassword(Long userId, String password) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessLogicException(ExceptionType.NOT_FOUND_USER));
+
+        if (!passwordEncoder.matches(password, user.getPassword())) {
+            throw new BusinessLogicException(ExceptionType.INVALID_PASSWORD);
+        }
+    }
+
+    @Transactional
+    public void updatePassword(Long userId, UserRequestDto.UpdatePassword request) {
+        verifyPassword(userId, request.getCurrentPassword());
+
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new BusinessLogicException(ExceptionType.NOT_FOUND_USER));
+
+        String encodedNewPassword = passwordEncoder.encode(request.getNewPassword());
+        user.changePassword(encodedNewPassword);
+    }
+
     public User findUserById(Long id) {
         return userRepository.findById(id)
             .orElseThrow(() -> new BusinessLogicException(ExceptionType.NOT_FOUND_USER));
-
     }
 }

--- a/src/main/java/com/talkit/app/global/exception/ExceptionType.java
+++ b/src/main/java/com/talkit/app/global/exception/ExceptionType.java
@@ -12,7 +12,7 @@ public enum ExceptionType {
     OK(HttpStatus.OK, "Success"),
 
     // BAD_REQUEST(400)
-
+    INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "현재 비밀번호가 일치하지 않습니다."),
 
     // UNAUTHORIZED(401)
     // 토큰 누락


### PR DESCRIPTION
# 🚀 관련 이슈
- 작업 내용 요약: 비밀번호 변경 전 본인 확인 절차 및 변경 API 구현

# ✨ 작업 목적
- 사용자의 보안 강화를 위해 비밀번호 변경 전 **현재 비밀번호를 먼저 검증**하는 단계를 추가하였습니다.
- 새로운 비밀번호를 암호화하여 안전하게 변경할 수 있는 전용 API를 구축하였습니다.

# 🛠️ 주요 변경 사항

### 1. 현재 비밀번호 검증 API 추가
- `POST /api/users/verify-password` 엔드포인트를 구현하였습니다.
- 현재 로그인된 사용자의 입력 비번과 DB의 암호화된 비번을 비교합니다.

### 2. 비밀번호 변경 기능 구현
- `PATCH /api/users/update-password` 엔드포인트를 구현하였습니다.
- 현재 비밀번호 재검증 후, 새로운 비밀번호를 암호화하여 업데이트합니다.

### 3. 예외 처리 강화
- `ExceptionType.INVALID_PASSWORD`를 추가하여 비밀번호가 틀렸을 때 명확한 에러 메시지(`400 Bad Request`)를 반환하도록 설계하였습니다.

### 4. 도메인 및 DTO 구조화
- `User` 엔티티 내에 `changePassword` 메서드를 추가하여 캡슐화를 유지했습니다.
- `UpdatePassword` DTO를 통해 안전하게 데이터를 전달받습니다.

# 📸 테스트 결과
- [x] 현재 비밀번호 불일치 시 `400` 에러 반환 확인
- [x] 현재 비밀번호 일치 시 `true` 응답 확인 (프론트엔드 모달 오픈 연동 확인)
- [x] 비밀번호 변경 완료 후 바뀐 비밀번호로 로그인 성공 확인
