### PR TITLE
[ feat ] : 커뮤니티 좋아요 기능 구현 및 사용자 유효성 검증 추가

### DIFF
--- a/src/main/java/com/talkit/app/domain/community/dto/CommunityCommentRequestDto.java
+++ b/src/main/java/com/talkit/app/domain/community/dto/CommunityCommentRequestDto.java
@@ -2,7 +2,10 @@ package com.talkit.app.domain.community.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record CommunityCommentRequestDto(@NotBlank(message = "댓글 내용을 입력해주세요.")
-                                        String content) {
+public record CommunityCommentRequestDto(
 
+    @NotBlank(message = "댓글 내용을 입력해주세요.")
+    String content
+
+) {
 }

--- a/src/main/java/com/talkit/app/domain/community/dto/CommunityResponseDto.java
+++ b/src/main/java/com/talkit/app/domain/community/dto/CommunityResponseDto.java
@@ -15,13 +15,20 @@ public record CommunityResponseDto(
     String nickname,
     List<String> tags,
     int likeCount,
-    int commentCount,
     boolean isLiked,
+    int commentCount,
     boolean isOwnedByUser,
     LocalDateTime createdAt,
     LocalDateTime updatedAt
 ) {
+
     public static CommunityResponseDto of(Community community, Long userId) {
+        return CommunityResponseDto.of(community, userId, false, 0, 0);
+    }
+
+    public static CommunityResponseDto of(
+        Community community, Long userId, boolean isLiked, int likeCount, int commentCount
+    ) {
         return CommunityResponseDto.builder()
             .id(community.getId())
             .title(community.getTitle())
@@ -29,6 +36,9 @@ public record CommunityResponseDto(
             .category(community.getCategory())
             .nickname(community.getUser().getNickname())
             .tags(community.getTags())
+            .likeCount(likeCount)
+            .isLiked(isLiked)
+            .commentCount(commentCount)
             .isOwnedByUser(community.getUser().getId().equals(userId))
             .createdAt(community.getCreatedAt())
             .updatedAt(community.getUpdatedAt())

--- a/src/main/java/com/talkit/app/domain/community/service/CommunityService.java
+++ b/src/main/java/com/talkit/app/domain/community/service/CommunityService.java
@@ -5,7 +5,6 @@ import static com.talkit.app.global.exception.ExceptionType.NOT_FOUND_USER;
 import static com.talkit.app.global.exception.ExceptionType.UNAUTHORIZED_NO_AUTHENTICATION_CONTEXT;
 
 import com.talkit.app.domain.community.dto.*;
-import com.talkit.app.domain.community.entity.Comment;
 import com.talkit.app.domain.community.entity.Community;
 import com.talkit.app.domain.community.repository.CommunityCommentRepository;
 import com.talkit.app.domain.community.repository.CommunityRepository;
@@ -18,10 +17,8 @@ import com.talkit.app.global.page.dto.PageResponseDto;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Arrays;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,7 +35,12 @@ public class CommunityService {
     public CommunityResponseDto getCommunityById(Long id, Long userId) {
         Community community = getCommunity(id);
 
-        return CommunityResponseDto.of(community, userId);
+        boolean isLiked = !userId.equals(User.ANONYMOUS_USER_ID) &&
+            communityLikeRepository.findByUserIdAndCommunityId(userId, id).isPresent();
+        int likeCount = communityLikeRepository.countByCommunityId(id);
+        int commentCount = communityCommentRepository.countByCommunityId(id);
+
+        return CommunityResponseDto.of(community, userId, isLiked, likeCount, commentCount);
     }
 
     public PageResponseDto<CommunityListResponseDto> pagesByCommunity(Long userId, PageRequestVO pageRequestVO) {
@@ -95,7 +97,7 @@ public class CommunityService {
         return CommunityResponseDto.of(community, userId);
     }
 
-    private Community getCommunity(Long id) {
+    public Community getCommunity(Long id) {
         return communityRepository.findWithTagsById(id)
             .orElseThrow(NOT_FOUND_COMMUNITY::of);
     }
@@ -119,41 +121,4 @@ public class CommunityService {
 
         communityRepository.delete(community);
     }
-
-
-    @Transactional
-    public CommunityCommentResponseDto createComment(Long communityId, CommunityCommentRequestDto requestDto, Long userId) {
-        Community community = communityRepository.findById(communityId)
-                .orElseThrow(NOT_FOUND_COMMUNITY::of);
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(NOT_FOUND_USER::of);
-
-        Comment comment = Comment.builder()
-                .community(community)
-                .user(user)
-                .content(requestDto.content())
-                .build();
-
-        communityCommentRepository.save(comment);
-
-        return CommunityCommentResponseDto.of(comment, userId);
-    }
-
-    /**
-     * 댓글 목록 조회 (페이징 적용)
-     */
-    public PageResponseDto<CommunityCommentResponseDto> getComments(Long communityId, Long userId, Pageable pageable) {
-        // 게시글 존재 확인
-        if (!communityRepository.existsById(communityId)) {
-            throw NOT_FOUND_COMMUNITY.of();
-        }
-
-        // 리포지토리의 findByCommunityId 활용
-        return PageResponseDto.of(
-                communityCommentRepository.findByCommunityId(communityId, pageable)
-                        .map(comment -> CommunityCommentResponseDto.of(comment, userId))
-        );
-    }
-
 }

--- a/src/main/java/com/talkit/app/domain/like/controller/CommunityLikeController.java
+++ b/src/main/java/com/talkit/app/domain/like/controller/CommunityLikeController.java
@@ -1,0 +1,49 @@
+package com.talkit.app.domain.like.controller;
+
+import com.talkit.app.domain.like.dto.CommunityLikeResponseDto;
+import com.talkit.app.domain.like.service.CommunityLikeService;
+import com.talkit.app.global.auth.AuthenticatedUser;
+import com.talkit.app.global.auth.AuthenticationHolder;
+import com.talkit.app.global.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@Tag(name = "커뮤니티 좋아요 API", description = "커뮤니티 게시물 좋아요")
+@RequestMapping("/api/community/{id}/like")
+@RestController
+public class CommunityLikeController {
+
+    private final CommunityLikeService communityLikeService;
+
+    @Operation(summary = "게시물 좋아요 상태 조회")
+    @AuthenticatedUser
+    @GetMapping("/status")
+    public ResponseDto<Boolean> getCommunityLikeStatus(@PathVariable("id") Long id) {
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityLikeService.isLiked(id, userId));
+    }
+
+    @Operation(summary = "게시물 좋아요 개수 조회")
+    @GetMapping("/count")
+    public ResponseDto<Long> getCommunityLikeCount(@PathVariable("id") Long id) {
+        long likeCount = communityLikeService.getLikeCount(id);
+        return ResponseDto.of(likeCount);
+    }
+
+    @Operation(summary = "좋아요 상태 변경(Toggle)")
+    @AuthenticatedUser
+    @PostMapping("/toggle")
+    public ResponseDto<CommunityLikeResponseDto> toggleRecipeLike(@PathVariable Long id) {
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(communityLikeService.toggleLike(id, userId));
+    }
+
+
+}

--- a/src/main/java/com/talkit/app/domain/like/dto/CommunityLikeResponseDto.java
+++ b/src/main/java/com/talkit/app/domain/like/dto/CommunityLikeResponseDto.java
@@ -1,0 +1,16 @@
+package com.talkit.app.domain.like.dto;
+
+import lombok.Builder;
+import lombok.Getter; // 추가
+
+@Getter
+@Builder
+public class CommunityLikeResponseDto {
+    private final Long communityId;
+
+    public static CommunityLikeResponseDto of(Long communityId) {
+        return CommunityLikeResponseDto.builder()
+            .communityId(communityId)
+            .build();
+    }
+}

--- a/src/main/java/com/talkit/app/domain/like/entity/CommunityLike.java
+++ b/src/main/java/com/talkit/app/domain/like/entity/CommunityLike.java
@@ -43,4 +43,11 @@ public class CommunityLike extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "community_id", nullable = false)
     private Community community; //글 식별키
+
+    public static CommunityLike of(User user, Community community) {
+        return CommunityLike.builder()
+            .user(user)
+            .community(community)
+            .build();
+    }
 }

--- a/src/main/java/com/talkit/app/domain/like/service/CommunityLikeService.java
+++ b/src/main/java/com/talkit/app/domain/like/service/CommunityLikeService.java
@@ -1,0 +1,48 @@
+package com.talkit.app.domain.like.service;
+
+import com.talkit.app.domain.community.entity.Community;
+import com.talkit.app.domain.community.repository.CommunityRepository;
+import com.talkit.app.domain.community.service.CommunityService;
+import com.talkit.app.domain.like.dto.CommunityLikeResponseDto;
+import com.talkit.app.domain.like.entity.CommunityLike;
+import com.talkit.app.domain.like.repository.CommunityLikeRepository;
+import com.talkit.app.domain.user.entity.User;
+import com.talkit.app.domain.user.repository.UserRepository;
+import com.talkit.app.domain.user.service.UserService;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class CommunityLikeService {
+
+    private final CommunityLikeRepository communityLikeRepository;
+    private final CommunityService communityService;
+    private final UserService userService;
+
+    public boolean isLiked(Long id, Long userId) {
+        return communityLikeRepository.findByUserIdAndCommunityId(userId, id).isPresent();
+    }
+
+    public long getLikeCount(Long id) {
+        return communityLikeRepository.countByCommunityId(id);
+    }
+
+    @Transactional
+    public CommunityLikeResponseDto toggleLike(Long communityId, Long userId) {
+        Optional<CommunityLike> like = communityLikeRepository.findByUserIdAndCommunityId(userId, communityId);
+
+        if (like.isPresent()) {
+            communityLikeRepository.delete(like.get());
+        } else {
+            User user = userService.findUserById(userId);
+            Community community = communityService.getCommunity(communityId);
+            communityLikeRepository.save(CommunityLike.of(user, community));
+        }
+        return CommunityLikeResponseDto.of(communityId);
+    }
+
+}

--- a/src/main/java/com/talkit/app/domain/user/dto/UserRequestDto.java
+++ b/src/main/java/com/talkit/app/domain/user/dto/UserRequestDto.java
@@ -1,5 +1,6 @@
 package com.talkit.app.domain.user.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
@@ -27,15 +28,10 @@ public class UserRequestDto {
 
     @Getter
     public static class UpdatePassword {
+        @NotBlank(message = "현재 비밀번호를 입력해주세요.")
         private String currentPassword;
+
+        @NotBlank(message = "새로운 비밀번호를 입력해주세요.")
         private String newPassword;
-
-        public String getCurrentPassword() {
-            return currentPassword;
-        }
-
-        public String getNewPassword() {
-            return newPassword;
-        }
     }
 }


### PR DESCRIPTION
### 1. 개요 (Description)
이번 PR에서는 커뮤니티 게시물의 사용자 상호작용(좋아요) 기능을 구현하고, 
사용자 정보 변경 시 발생하던 보안 취약점(공백 비밀번호 허용)을 개선했습니다.

### 2. 주요 변경 사항 (Key Changes)

#### ✨ 커뮤니티 좋아요 (Community Like)
- **좋아요 토글 기능 구현**: 사용자가 게시물을 좋아요/취소할 수 있는 로직을 추가했습니다.
- **조회 API 추가**: 특정 게시물의 좋아요 총 개수 및 현재 사용자의 좋아요 여부를 확인할 수 있는 API를 구현했습니다.
- **상태 관리**: 중복 좋아요 방지 및 데이터 무결성을 위한 비즈니스 로직을 서비스 레이어에 작성했습니다.

#### 🔒 유효성 검증 (User Validation)
- **비밀번호 변경 로직 보안 강화**: `UpdatePassword` DTO에 `@NotBlank`를 적용하여 비밀번호를 입력하지 않거나 공백으로 제출되는 경우를 차단했습니다.
- **코드 최적화**: 수동으로 작성된 Getter를 Lombok의 `@Getter`로 대체하여 코드 가독성과 유지보수성을 높였습니다.

### 3. API 엔드포인트 (API Endpoints)

| Method | Path | Description |
|:---:|:---|:---|
| `POST` | `/api/community/{id}/like/toggle` | 좋아요 토글 (Toggle) |
| `GET` | `/api/community/{id}/like/status` | 현재 사용자의 좋아요 여부 확인 |
| `GET` | `/api/community/{id}/like/count` | 게시물 전체 좋아요 개수 조회 |