### PR TITLE
[ feat ] : 커뮤니티 리스트 API 내 조회수(viewCount) 필드 추가 및 Dto 수정

### DIFF
--- a/src/main/java/com/talkit/app/domain/community/dto/CommunityListResponseDto.java
+++ b/src/main/java/com/talkit/app/domain/community/dto/CommunityListResponseDto.java
@@ -12,45 +12,61 @@ public record CommunityListResponseDto(
     String content,
     String category,
     String nickname,
+    List<String> tags,
+    boolean isLiked,
     int likeCount,
     int commentCount,
-    boolean isLiked
+    int viewCount
 ) {
 
     public static CommunityListResponseDto from(Community community) {
-
         return CommunityListResponseDto.builder()
             .id(community.getId().toString())
             .title(community.getTitle())
-            .content(getPreviewContent(community.getContent(), 250))
+            .content(getPreviewContent(community.getContent(), 150))
             .nickname(community.getUser().getNickname())
             .category(community.getCategory())
+            .tags(community.getTags())
+            .viewCount(community.getViewCount())
             .build();
     }
 
-    public static CommunityListResponseDto of(Community community,
+    public static CommunityListResponseDto of(
+        Community community,
         int likeCount,
         int commentCount,
         List<CommunityLike> communityLikesByUserId) {
 
+        // 1. 기초 정보 생성
+        CommunityListResponseDto base = from(community);
+
+        // 2. 추가 정보(좋아요 여부) 계산
+        boolean isLiked = communityLikesByUserId.stream()
+            .anyMatch(like -> community.getId().equals(like.getCommunity().getId()));
+
+        // 3. 전체 조립
         return CommunityListResponseDto.builder()
-            .id(community.getId().toString())
-            .title(community.getTitle())
-            .category(community.getCategory())
+            .id(base.id())
+            .title(base.title())
+            .content(base.content())
+            .nickname(base.nickname())
+            .category(base.category())
+            .tags(base.tags())
+            .viewCount(base.viewCount())
             .likeCount(likeCount)
-            .nickname(community.getUser().getNickname())
             .commentCount(commentCount)
-            .isLiked(communityLikesByUserId.stream()
-                .anyMatch(communityLike -> community.getId().equals(communityLike.getCommunity().getId())))
-            .content(getPreviewContent(community.getContent(), 150))
+            .isLiked(isLiked) // 미리 계산한 변수 사용
             .build();
     }
 
     private static String getPreviewContent(String content, int maxLength) {
+        // null 체크 및 빈 문자열 처리 추가
+        if (content == null || content.isBlank()) {
+            return "";
+        }
         if (content.length() > maxLength) {
-            return content.substring(0, maxLength);
+            return content.substring(0, maxLength) + "..."; // 줄임표(...)를 넣어주면 UX에 좋습니다.
         }
         return content;
     }
 }
-

--- a/src/main/java/com/talkit/app/domain/community/dto/CommunityResponseDto.java
+++ b/src/main/java/com/talkit/app/domain/community/dto/CommunityResponseDto.java
@@ -14,6 +14,7 @@ public record CommunityResponseDto(
     String category,
     String nickname,
     List<String> tags,
+    int viewCount,
     int likeCount,
     boolean isLiked,
     int commentCount,
@@ -36,6 +37,7 @@ public record CommunityResponseDto(
             .category(community.getCategory())
             .nickname(community.getUser().getNickname())
             .tags(community.getTags())
+            .viewCount(community.getViewCount())
             .likeCount(likeCount)
             .isLiked(isLiked)
             .commentCount(commentCount)

--- a/src/main/java/com/talkit/app/domain/community/entity/Community.java
+++ b/src/main/java/com/talkit/app/domain/community/entity/Community.java
@@ -39,18 +39,25 @@ public class Community extends BaseEntity {
     @Column(name = "category", nullable = false)
     private String category;
 
+    @Column(name = "view_count", nullable = false)
+    @Builder.Default
+    private int viewCount = 0;
+
     @OneToMany(mappedBy = "community", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> commentList = new ArrayList<>();
 
     @OneToMany(mappedBy = "community", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CommunityLike> communityLikeList = new ArrayList<>();
 
-
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "community_tags", joinColumns = @JoinColumn(name = "community_id"))
     @Column(name = "tag_name")
     @Builder.Default // Builder 사용 시 리스트 초기화 보장
     private List<String> tags = new ArrayList<>();
+
+    public void incrementViewCount() {
+        this.viewCount++;
+    }
 
     // 생성 메서드 수정
     public static Community of(User user, String title, String content, String category, List<String> tags) {
@@ -62,7 +69,6 @@ public class Community extends BaseEntity {
                 .tags(tags)
                 .build();
     }
-
 
     public void update(String title, String content, String category,List<String> tags) {
 

--- a/src/main/java/com/talkit/app/domain/community/service/CommunityService.java
+++ b/src/main/java/com/talkit/app/domain/community/service/CommunityService.java
@@ -32,8 +32,10 @@ public class CommunityService {
     private final CommunityCommentRepository communityCommentRepository;
     private final UserRepository userRepository;
 
+    @Transactional
     public CommunityResponseDto getCommunityById(Long id, Long userId) {
         Community community = getCommunity(id);
+        community.incrementViewCount();
 
         boolean isLiked = !userId.equals(User.ANONYMOUS_USER_ID) &&
             communityLikeRepository.findByUserIdAndCommunityId(userId, id).isPresent();


### PR DESCRIPTION
- Community 엔티티 및 DTO에 조회수(viewCount) 필드 추가
- CommunityService 내 조회수 처리 및 리스트/상세 데이터 매핑 로직 구현
- 프론트엔드 UI 요구사항(닉네임, 카테고리, 태그)에 맞춘 응답 규격 최적화