### PR TITLE
[ feat ] : Gemini API 연동 및 AI 채팅 폴더 구조 세팅

### DIFF
--- a/src/main/java/com/talkit/app/domain/aiChat/controller/AiChatController.java
+++ b/src/main/java/com/talkit/app/domain/aiChat/controller/AiChatController.java
@@ -1,0 +1,32 @@
+package com.talkit.app.domain.aiChat.controller;
+
+import com.talkit.app.domain.aiChat.dto.AiChatMessageRequest;
+import com.talkit.app.domain.aiChat.service.AiChatService;
+import com.talkit.app.global.auth.AuthenticatedUser;
+import com.talkit.app.global.auth.AuthenticationHolder;
+import com.talkit.app.global.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@Tag(name = "AI 채팅 관련 API", description = "AI 채팅 관련 API")
+@RequestMapping("/api/ai-chat")
+@RestController
+public class AiChatController {
+
+    private final AiChatService aiChatService;
+
+    @Operation(summary = "제미나이 AI 채팅 테스트")
+    @AuthenticatedUser
+    @PostMapping("/test")
+    public ResponseDto<String> testChat(@RequestBody AiChatMessageRequest request) {
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        String aiAnswer = aiChatService.getGeminiContents(request.message(), userId);
+        return ResponseDto.of(aiAnswer, "AI 답변을 성공적으로 가져왔습니다.");
+    }
+}

--- a/src/main/java/com/talkit/app/domain/aiChat/dto/AiChatMessageRequest.java
+++ b/src/main/java/com/talkit/app/domain/aiChat/dto/AiChatMessageRequest.java
@@ -1,0 +1,7 @@
+package com.talkit.app.domain.aiChat.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AiChatMessageRequest(String message) {
+}

--- a/src/main/java/com/talkit/app/domain/aiChat/dto/AiChatRoomCreateRequest.java
+++ b/src/main/java/com/talkit/app/domain/aiChat/dto/AiChatRoomCreateRequest.java
@@ -1,0 +1,7 @@
+package com.talkit.app.domain.aiChat.dto;
+
+import lombok.Builder;
+
+@Builder
+public record AiChatRoomCreateRequest(Long situationId) {
+}

--- a/src/main/java/com/talkit/app/domain/aiChat/dto/AiChatRoomResponse.java
+++ b/src/main/java/com/talkit/app/domain/aiChat/dto/AiChatRoomResponse.java
@@ -1,0 +1,21 @@
+package com.talkit.app.domain.aiChat.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Builder
+public record AiChatRoomResponse(
+        Long chatRoomId,           // 생성된/조회된 방 번호
+        String situationTitle,     // 상황 제목 (예: 첫 데이트)
+        String situationDescription, // 상황 설명
+        List<ChatMessageDetail> messages // 이전 대화 목록
+) {
+    @Builder
+    public record ChatMessageDetail(
+            String role,           // "USER" 또는 "ASSISTANT" (Gemini 방식)
+            String content,        // 메시지 내용
+            LocalDateTime createdAt // 보낸 시간
+    ) {}
+}

--- a/src/main/java/com/talkit/app/domain/aiChat/dto/GeminiRequestDto.java
+++ b/src/main/java/com/talkit/app/domain/aiChat/dto/GeminiRequestDto.java
@@ -1,0 +1,19 @@
+package com.talkit.app.domain.aiChat.dto;
+
+import lombok.Builder;
+import java.util.List;
+
+@Builder
+public record GeminiRequestDto(List<Content> contents) {
+
+    public record Content(List<Part> parts) {}
+
+    public record Part(String text) {}
+
+    // 편의 메서드: 이 메서드를 호출하면 위 봉투들을 순서대로 조립해줍니다.
+    public static GeminiRequestDto fromText(String text) {
+        Part part = new Part(text);
+        Content content = new Content(List.of(part));
+        return new GeminiRequestDto(List.of(content));
+    }
+}

--- a/src/main/java/com/talkit/app/domain/aiChat/dto/GeminiResponseDto.java
+++ b/src/main/java/com/talkit/app/domain/aiChat/dto/GeminiResponseDto.java
@@ -1,0 +1,30 @@
+package com.talkit.app.domain.aiChat.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GeminiResponseDto(List<Candidate> candidates) {
+
+    public record Candidate(
+            Content content,
+            String finishReason
+    ) {}
+
+    public record Content(
+            List<Part> parts,
+            String role
+    ) {}
+
+    public record Part(
+            String text
+    ) {}
+
+    // 응답 결과물에서 AI의 답변 텍스트만 추출
+    public String getAnswer() {
+        if (candidates == null || candidates.isEmpty()) return "";
+
+        return candidates.get(0).content().parts().get(0).text();
+    }
+}

--- a/src/main/java/com/talkit/app/domain/aiChat/entity/AiChatMessage.java
+++ b/src/main/java/com/talkit/app/domain/aiChat/entity/AiChatMessage.java
@@ -1,0 +1,37 @@
+package com.talkit.app.domain.aiChat.entity;
+
+import com.talkit.app.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "ai_chat_message")
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiChatMessage extends BaseEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ai_chatting_id")
+    private AiChatRoom aiChatRoom;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "message_type", nullable = false)
+    private MessageType type;
+
+    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    private String content;
+
+    public enum MessageType {
+        AI, USER, SYSTEM, NOTICE
+    }
+}

--- a/src/main/java/com/talkit/app/domain/aiChat/entity/AiChatRoom.java
+++ b/src/main/java/com/talkit/app/domain/aiChat/entity/AiChatRoom.java
@@ -1,0 +1,39 @@
+package com.talkit.app.domain.aiChat.entity;
+
+import com.talkit.app.domain.aiSituation.entity.AiSituation;
+import com.talkit.app.domain.user.entity.User;
+import com.talkit.app.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "ai_chat_room")
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiChatRoom extends BaseEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ai_situation_id", nullable = false)
+    private AiSituation aiSituation;
+
+    @OneToMany(mappedBy = "aiChatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AiChatMessage> messages = new ArrayList<>();
+
+}

--- a/src/main/java/com/talkit/app/domain/aiChat/repository/AiChatRepository.java
+++ b/src/main/java/com/talkit/app/domain/aiChat/repository/AiChatRepository.java
@@ -1,0 +1,9 @@
+package com.talkit.app.domain.aiChat.repository;
+
+import com.talkit.app.domain.aiChat.entity.AiChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AiChatRepository extends JpaRepository<AiChatRoom, Long> {
+}

--- a/src/main/java/com/talkit/app/domain/aiChat/service/AiChatService.java
+++ b/src/main/java/com/talkit/app/domain/aiChat/service/AiChatService.java
@@ -1,0 +1,45 @@
+package com.talkit.app.domain.aiChat.service;
+
+import com.talkit.app.domain.aiChat.dto.GeminiRequestDto;
+import com.talkit.app.domain.aiChat.dto.GeminiResponseDto;
+import com.talkit.app.domain.user.entity.User;
+import com.talkit.app.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import static com.talkit.app.global.exception.ExceptionType.NOT_FOUND_USER;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class AiChatService {
+
+    private final UserRepository userRepository;
+
+    private final RestTemplate restTemplate;
+
+    @Value("${custom.gemini.url}")
+    private String apiUrl;
+
+    @Value("${custom.gemini.key}")
+    private String apiKey;
+
+    @Transactional
+    public String getGeminiContents(String prompt, Long userId) {
+
+        User user = userRepository.findById(userId).orElseThrow(NOT_FOUND_USER::of);
+
+        String requestUrl = apiUrl + "?key=" + apiKey;
+        GeminiRequestDto request = GeminiRequestDto.fromText(prompt);
+        GeminiResponseDto response = restTemplate.postForObject(requestUrl, request, GeminiResponseDto.class);
+
+        String aiAnswer = (response != null) ? response.getAnswer() : "답변을 가져오지 못했습니다.";
+        // saveChatMessage(user, message, aiAnswer);
+
+        return aiAnswer;
+    }
+
+}

--- a/src/main/java/com/talkit/app/domain/aiSituation/controller/AiSituationController.java
+++ b/src/main/java/com/talkit/app/domain/aiSituation/controller/AiSituationController.java
@@ -1,0 +1,13 @@
+package com.talkit.app.domain.aiSituation.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@Tag(name = "AI 채팅 관련 API", description = "AI 채팅 관련 API")
+@RequestMapping("/api/cahtting-ai")
+@RestController
+public class AiSituationController {
+}

--- a/src/main/java/com/talkit/app/domain/aiSituation/entity/AiSituation.java
+++ b/src/main/java/com/talkit/app/domain/aiSituation/entity/AiSituation.java
@@ -1,0 +1,36 @@
+package com.talkit.app.domain.aiSituation.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "ai_situation")
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AiSituation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ai_situation_id")
+    private Long id;
+
+    @Column(name = "icon", nullable = false)
+    private String icon;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Column(name = "description", nullable = false)
+    private String description;
+
+    @Column(name = "status", nullable = false)
+    private String status;
+
+    @Column(name = "status_color", nullable = false)
+    private String statusColor;
+}

--- a/src/main/java/com/talkit/app/domain/aiSituation/repository/AiSituationRepository.java
+++ b/src/main/java/com/talkit/app/domain/aiSituation/repository/AiSituationRepository.java
@@ -1,0 +1,9 @@
+package com.talkit.app.domain.aiSituation.repository;
+
+import com.talkit.app.domain.aiSituation.entity.AiSituation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AiSituationRepository extends JpaRepository<AiSituation, Long> {
+}

--- a/src/main/java/com/talkit/app/domain/aiSituation/service/AiSituationService.java
+++ b/src/main/java/com/talkit/app/domain/aiSituation/service/AiSituationService.java
@@ -1,0 +1,16 @@
+package com.talkit.app.domain.aiSituation.service;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class AiSituationService {
+
+}

--- a/src/main/java/com/talkit/app/global/config/GeminiConfig.java
+++ b/src/main/java/com/talkit/app/global/config/GeminiConfig.java
@@ -1,4 +1,27 @@
 package com.talkit.app.global.config;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
 public class GeminiConfig {
+
+    // yml 설정 경로와 맞춤: custom.gemini.key
+    @Value("${custom.gemini.key}")
+    private String geminiApiKey;
+
+    @Bean
+    public RestTemplate geminiRestTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+
+        restTemplate.getInterceptors().add((request, body, execution) -> {
+            request.getHeaders().add("x-goog-api-key", geminiApiKey);
+            return execution.execute(request, body);
+        });
+
+        return restTemplate;
+    }
 }

--- a/src/main/java/com/talkit/app/global/config/SecurityConfig.java
+++ b/src/main/java/com/talkit/app/global/config/SecurityConfig.java
@@ -80,7 +80,8 @@ public class SecurityConfig {
                 .requestMatchers(
                     "/api/community/**",
                     "/api/stats/**",
-                    "/api/auth/user"
+                    "/api/auth/user",
+                    "/api/ai-chat/**"
                 ).hasAuthority("ROLE_USER")
 
                 .anyRequest().authenticated()


### PR DESCRIPTION
1. 엔터티 (Entity) 및 테이블 설계
- AiSituation: AI가 처한 상황이나 페르소나를 정의하는 테이블.
- AiChatRoom: 유저와 AI 간의 채팅 방 세션을 관리하는 테이블.
- AiChatMessage: 실제 주고받은 메시지 내역을 저장하는 테이블.

2. DTO (Data Transfer Object) 구현
- AiChatRequest: 유저가 보내는 메시지를 담는 객체.
- AiChatResponse: 제미나이의 답변과 상태 메시지를 전달하는 객체.

3. Gemini API 연동 설정 (application.yml & AiChatService)
- custom.gemini 계층 구조를 사용하여 API Key와 URL을 관리하도록 설정
- v1beta 버전의 gemini-3-flash-preview 모델을 사용하여 연동 완료
- RestTemplate을 이용해 구글 서버와 JSON 데이터를 주고받는 로직을 완성

4. Security 설정 업데이트 (SecurityConfig)
- /api/ai-chat/** 경로에 대해 ROLE_USER 권한이 있는 사용자만 접근할 수 있도록 인가 설정 추가
- CORS 설정을 통해 프론트엔드(Next.js 등)와의 통신 기반을 마련

<img width="100%" height="10%" alt="image" src="https://github.com/user-attachments/assets/e8c06a26-4a79-4102-8eb4-27133517119c" />
