### PR TITLE
[ feat ] : 커뮤니티 목록 상단 부분 통계 조회용 API 구현

### DIFF
--- a/src/main/java/com/talkit/app/domain/community/controller/CommunityController.java
+++ b/src/main/java/com/talkit/app/domain/community/controller/CommunityController.java
@@ -1,9 +1,6 @@
 package com.talkit.app.domain.community.controller;
 
-import com.talkit.app.domain.community.dto.CommunityListResponseDto;
-import com.talkit.app.domain.community.dto.CommunityRequestDto;
-import com.talkit.app.domain.community.dto.CommunityResponseDto;
-import com.talkit.app.domain.community.dto.CommunitySearchConditionDto;
+import com.talkit.app.domain.community.dto.*;
 import com.talkit.app.domain.community.service.CommunityService;
 import com.talkit.app.global.auth.AuthenticatedUser;
 import com.talkit.app.global.auth.AuthenticationHolder;
@@ -74,6 +71,12 @@ public class CommunityController {
         Long userId = AuthenticationHolder.getCurrentUserId();
         communityService.deleteCommunity(id, userId);
         return ResponseDto.of(null, "게시물이 성공적으로 삭제되었습니다.");
+    }
+
+    @Operation(summary = "커뮤니티 통계 조회", description = "메인 상단 Hero Section에 표시될 게시글, 댓글, 활동멤버 수를 조회합니다.")
+    @GetMapping("/stats")
+    public ResponseDto<CommunityStatsResponseDto> getCommunityStats() {
+        return ResponseDto.of(communityService.getCommunityStats());
     }
 
 }

--- a/src/main/java/com/talkit/app/domain/community/dto/CommunityStatsResponseDto.java
+++ b/src/main/java/com/talkit/app/domain/community/dto/CommunityStatsResponseDto.java
@@ -1,0 +1,18 @@
+package com.talkit.app.domain.community.dto;
+
+import lombok.Builder;
+
+@Builder
+public record CommunityStatsResponseDto(
+        long totalPostCount,     // 전체 게시글 수
+        long totalCommentCount,  // 전체 댓글 수
+        long activeUserCount     // 활동 멤버 수
+) {
+    public static CommunityStatsResponseDto of(long totalPostCount, long totalCommentCount, long activeUserCount) {
+        return CommunityStatsResponseDto.builder()
+                .totalPostCount(totalPostCount)
+                .totalCommentCount(totalCommentCount)
+                .activeUserCount(activeUserCount)
+                .build();
+    }
+}

--- a/src/main/java/com/talkit/app/domain/community/service/CommunityService.java
+++ b/src/main/java/com/talkit/app/domain/community/service/CommunityService.java
@@ -45,20 +45,6 @@ public class CommunityService {
         return CommunityResponseDto.of(community, userId, isLiked, likeCount, commentCount);
     }
 
-    public PageResponseDto<CommunityListResponseDto> pagesByCommunity(
-            CommunitySearchConditionDto condition, Long userId, PageRequestVO pageRequestVO
-    ) {
-        List<CommunityLike> communityLikes = getCommunityLikesBy(userId);
-
-        return PageResponseDto.of((communityRepository.searchByCondition(condition, pageRequestVO.toPageable()))
-            .map(community -> {
-                int likeCount = communityLikeRepository.countByCommunityId(community.getId());
-                int commentCount = communityCommentRepository.countByCommunityId(community.getId());
-                return CommunityListResponseDto.of(community, likeCount, commentCount, communityLikes);
-            })
-        );
-    }
-
     @Transactional
     public CommunityResponseDto createCommunity(CommunityRequestDto requestDto, Long userId) {
         User user = userRepository.findById(userId)
@@ -77,7 +63,6 @@ public class CommunityService {
         return CommunityResponseDto.of(community, userId);
     }
 
-
     @Transactional
     public CommunityResponseDto updateCommunity(Long id, CommunityRequestDto requestDto, Long userId) {
         Community community = getCommunity(id);
@@ -92,6 +77,30 @@ public class CommunityService {
         );
 
         return CommunityResponseDto.of(community, userId);
+    }
+
+    @Transactional(readOnly = true)
+    public CommunityStatsResponseDto getCommunityStats() {
+        long totalPosts = communityRepository.count();
+        long totalComments = communityCommentRepository.count();
+        long activeMembers = userRepository.countActiveMembers();
+
+        return CommunityStatsResponseDto.of(totalPosts, totalComments, activeMembers);
+    }
+
+
+    public PageResponseDto<CommunityListResponseDto> pagesByCommunity(
+            CommunitySearchConditionDto condition, Long userId, PageRequestVO pageRequestVO
+    ) {
+        List<CommunityLike> communityLikes = getCommunityLikesBy(userId);
+
+        return PageResponseDto.of((communityRepository.searchByCondition(condition, pageRequestVO.toPageable()))
+                .map(community -> {
+                    int likeCount = communityLikeRepository.countByCommunityId(community.getId());
+                    int commentCount = communityCommentRepository.countByCommunityId(community.getId());
+                    return CommunityListResponseDto.of(community, likeCount, commentCount, communityLikes);
+                })
+        );
     }
 
     public CommunityResponseDto getPostForEdit(Long id, Long userId) {

--- a/src/main/java/com/talkit/app/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/talkit/app/domain/user/repository/UserRepository.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,4 +18,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     List<User> findAllByDeleteAtBefore(LocalDate date);
 
     Optional<User> findByEmail(String email);
+
+    @Query("SELECT COUNT(DISTINCT u.id) FROM User u " +
+            "WHERE EXISTS (SELECT 1 FROM Community c WHERE c.user = u) " +
+            "OR EXISTS (SELECT 1 FROM Comment cc WHERE cc.user = u)")
+    long countActiveMembers();
 }


### PR DESCRIPTION
## 💡 개요
커뮤니티 메인 페이지 Hero Section에 표시될 실시간 통계 데이터를 조회하는 API를 구현했습니다.

## 🛠️ 주요 작업 내용
- **DTO**: `CommunityStatsResponseDto` 생성 (정적 팩토리 메서드 `of` 적용)
- **Repository**: `UserRepository`에 활동 멤버 수 카운트를 위한 커스텀 쿼리 추가
- **Service**: 게시글, 댓글, 활동 멤버 수의 전체 카운트를 집계하는 로직 구현
- **Controller**: `/api/community/stats` 엔드포인트 추가 (비회원 접근 허용)
