### PR TITLE
[ feat ] :  커뮤니티 북마크 기능 구현 및 순환 참조 구조 개선

### DIFF
--- a/src/main/java/com/talkit/app/domain/community/base/controller/CommunityController.java
+++ b/src/main/java/com/talkit/app/domain/community/base/controller/CommunityController.java
@@ -34,7 +34,7 @@ public class CommunityController {
 
     @Operation(summary = "게시물 목록 조회")
     @GetMapping("/list")
-    public ResponseDto<PageResponseDto<CommunityListResponseDto>> list(
+    public ResponseDto<PageResponseDto<CommunityListResponseDto>> getCommunityList(
             CommunitySearchConditionDto condition, PageRequestVO pageRequestVO
     ) {
         Long userId = AuthenticationHolder.getCurrentUserId();
@@ -52,7 +52,7 @@ public class CommunityController {
     @Operation(summary = "게시물 작성")
     @AuthenticatedUser
     @PostMapping("/create")
-    public ResponseDto<CommunityResponseDto> communityCreate(@RequestBody @Valid CommunityRequestDto requestDto) {
+    public ResponseDto<CommunityResponseDto> createCommunity(@RequestBody @Valid CommunityRequestDto requestDto) {
         Long userId = AuthenticationHolder.getCurrentUserId();
         return ResponseDto.of(communityService.createCommunity(requestDto, userId), "게시물이 성공적으로 생성되었습니다.");
     }
@@ -60,7 +60,7 @@ public class CommunityController {
     @Operation(summary = "게시물 수정")
     @AuthenticatedUser
     @PutMapping("/{id}")
-    public ResponseDto<CommunityResponseDto> update(
+    public ResponseDto<CommunityResponseDto> updateCommunity(
         @RequestBody @Valid CommunityRequestDto requestDto,
         @PathVariable("id") Long communityId) {
 
@@ -71,7 +71,7 @@ public class CommunityController {
     @Operation(summary = "게시물 삭제")
     @AuthenticatedUser // 인증 체크 어노테이션
     @DeleteMapping("/{id}")
-    public ResponseDto<Void> delete(@PathVariable("id") Long id) {
+    public ResponseDto<Void> deleteCommunity(@PathVariable("id") Long id) {
         Long userId = AuthenticationHolder.getCurrentUserId();
         communityService.deleteCommunity(id, userId);
         return ResponseDto.of(null, "게시물이 성공적으로 삭제되었습니다.");

--- a/src/main/java/com/talkit/app/domain/community/base/dto/CommunityResponseDto.java
+++ b/src/main/java/com/talkit/app/domain/community/base/dto/CommunityResponseDto.java
@@ -17,6 +17,7 @@ public record CommunityResponseDto(
     int viewCount,
     int likeCount,
     boolean isLiked,
+    boolean isBookmarked,
     int commentCount,
     boolean isOwnedByUser,
     LocalDateTime createdAt,
@@ -24,11 +25,11 @@ public record CommunityResponseDto(
 ) {
 
     public static CommunityResponseDto of(Community community, Long userId) {
-        return CommunityResponseDto.of(community, userId, false, 0, 0);
+        return CommunityResponseDto.of(community, userId, false, false, 0, 0);
     }
 
     public static CommunityResponseDto of(
-        Community community, Long userId, boolean isLiked, int likeCount, int commentCount
+        Community community, Long userId, boolean isLiked, boolean isBookmarked, int likeCount, int commentCount
     ) {
         return CommunityResponseDto.builder()
             .id(community.getId())
@@ -40,6 +41,7 @@ public record CommunityResponseDto(
             .viewCount(community.getViewCount())
             .likeCount(likeCount)
             .isLiked(isLiked)
+            .isBookmarked(isBookmarked)
             .commentCount(commentCount)
             .isOwnedByUser(community.getUser().getId().equals(userId))
             .createdAt(community.getCreatedAt())

--- a/src/main/java/com/talkit/app/domain/community/base/service/CommunityService.java
+++ b/src/main/java/com/talkit/app/domain/community/base/service/CommunityService.java
@@ -8,12 +8,13 @@ import com.talkit.app.domain.community.base.dto.CommunityListResponseDto;
 import com.talkit.app.domain.community.base.dto.CommunityRequestDto;
 import com.talkit.app.domain.community.base.dto.CommunityResponseDto;
 import com.talkit.app.domain.community.base.dto.CommunitySearchConditionDto;
+import com.talkit.app.domain.community.bookmark.service.BookmarkService;
 import com.talkit.app.domain.community.entity.Community;
 import com.talkit.app.domain.community.comment.repository.CommentRepository;
 import com.talkit.app.domain.community.base.repository.CommunityRepository;
 import com.talkit.app.domain.community.entity.CommunityLike;
-import com.talkit.app.domain.community.like.repository.CommunityLikeRepository;
 import com.talkit.app.domain.community.base.dto.CommunityStatsResponseDto;
+import com.talkit.app.domain.community.like.service.CommunityLikeService;
 import com.talkit.app.domain.user.entity.User;
 import com.talkit.app.domain.user.repository.UserRepository;
 import com.talkit.app.global.dto.PageRequestVO;
@@ -32,9 +33,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommunityService {
 
     private final CommunityRepository communityRepository;
-    private final CommunityLikeRepository communityLikeRepository;
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
+    private final BookmarkService bookmarkService;
+    private final CommunityLikeService communityLikeService;
 
     @Transactional
     public CommunityResponseDto getCommunityById(Long id, Long userId) {
@@ -42,11 +44,15 @@ public class CommunityService {
         community.incrementViewCount();
 
         boolean isLiked = !userId.equals(User.ANONYMOUS_USER_ID) &&
-            communityLikeRepository.findByUserIdAndCommunityId(userId, id).isPresent();
-        int likeCount = communityLikeRepository.countByCommunityId(id);
+                communityLikeService.isLiked(id, userId);
+
+        boolean isBookmarked = !userId.equals(User.ANONYMOUS_USER_ID) &&
+                bookmarkService.isBookmarked(id, userId);
+
+        int likeCount = (int) communityLikeService.getLikeCount(id);
         int commentCount = commentRepository.countByCommunityId(id);
 
-        return CommunityResponseDto.of(community, userId, isLiked, likeCount, commentCount);
+        return CommunityResponseDto.of(community, userId, isLiked, isBookmarked, likeCount, commentCount);
     }
 
     @Transactional
@@ -96,11 +102,11 @@ public class CommunityService {
     public PageResponseDto<CommunityListResponseDto> pagesByCommunity(
             CommunitySearchConditionDto condition, Long userId, PageRequestVO pageRequestVO
     ) {
-        List<CommunityLike> communityLikes = getCommunityLikesBy(userId);
+        List<CommunityLike> communityLikes = communityLikeService.getCommunityLikesByUserId(userId);
 
         return PageResponseDto.of((communityRepository.searchByCondition(condition, pageRequestVO.toPageable()))
                 .map(community -> {
-                    int likeCount = communityLikeRepository.countByCommunityId(community.getId());
+                    int likeCount = (int) communityLikeService.getLikeCount(community.getId());
                     int commentCount = commentRepository.countByCommunityId(community.getId());
                     return CommunityListResponseDto.of(community, likeCount, commentCount, communityLikes);
                 })
@@ -123,12 +129,6 @@ public class CommunityService {
         if (!community.getUser().getId().equals(userId)) {
             throw UNAUTHORIZED_NO_AUTHENTICATION_CONTEXT.of("게시물을 수정/삭제할 권한이 없습니다.");
         }
-    }
-
-    private List<CommunityLike> getCommunityLikesBy(Long userId) {
-        return userId.equals(User.ANONYMOUS_USER_ID)
-            ? new ArrayList<>()
-            : communityLikeRepository.findCommunityLikesByUserId(userId);
     }
 
     @Transactional

--- a/src/main/java/com/talkit/app/domain/community/bookMark/controller/BookmarkController.java
+++ b/src/main/java/com/talkit/app/domain/community/bookMark/controller/BookmarkController.java
@@ -1,0 +1,46 @@
+package com.talkit.app.domain.community.bookmark.controller;
+
+import com.talkit.app.domain.community.bookmark.dto.BookmarkResponseDto;
+import com.talkit.app.domain.community.bookmark.service.BookmarkService;
+import com.talkit.app.global.auth.AuthenticatedUser;
+import com.talkit.app.global.auth.AuthenticationHolder;
+import com.talkit.app.global.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Tag(name = "커뮤니티 북마크 API", description = "커뮤니티 '즐겨찾기/북마크' 관련 API")
+@RestController
+@RequestMapping("/api/community")
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @Operation(summary = "북마크 상태 변경(Toggle)", description = "북마크를 등록하거나 취소합니다.")
+    @AuthenticatedUser
+    @PostMapping("/{id}/bookmark/toggle")
+    public ResponseDto<Boolean> toggleBookMark(@PathVariable("id") Long id) {
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(bookmarkService.toggleBookMark(id, userId));
+    }
+
+    @Operation(summary = "게시물 북마크 상태 조회")
+    @AuthenticatedUser
+    @GetMapping("/{id}/bookmark/status")
+    public ResponseDto<Boolean> getBookMarkStatus(@PathVariable("id") Long id) {
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(bookmarkService.isBookmarked(id, userId));
+    }
+
+    @Operation(summary = "내 북마크 목록 조회")
+    @AuthenticatedUser
+    @GetMapping("/bookmark/my-list")
+    public ResponseDto<List<BookmarkResponseDto>> getMyBookMarkList() {
+        Long userId = AuthenticationHolder.getCurrentUserId();
+        return ResponseDto.of(bookmarkService.getMyBookMarks(userId));
+    }
+}

--- a/src/main/java/com/talkit/app/domain/community/bookMark/dto/BookmarkResponseDto.java
+++ b/src/main/java/com/talkit/app/domain/community/bookMark/dto/BookmarkResponseDto.java
@@ -1,0 +1,28 @@
+package com.talkit.app.domain.community.bookmark.dto;
+
+import com.talkit.app.domain.community.entity.Bookmark;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class BookmarkResponseDto {
+
+    private final Long bookmarkId;
+    private final Long communityId;
+    private final String title;
+    private final String category;
+    private final LocalDateTime createdAt;
+
+    public static BookmarkResponseDto of(Bookmark bookMark) {
+        return BookmarkResponseDto.builder()
+                .bookmarkId(bookMark.getId())
+                .communityId(bookMark.getCommunity().getId())
+                .title(bookMark.getCommunity().getTitle())
+                .category(bookMark.getCommunity().getCategory())
+                .createdAt(bookMark.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/talkit/app/domain/community/bookMark/repository/BookMarkRepository.java
+++ b/src/main/java/com/talkit/app/domain/community/bookMark/repository/BookMarkRepository.java
@@ -1,5 +1,21 @@
-package com.talkit.app.domain.community.bookMark.repository;
+package com.talkit.app.domain.community.bookmark.repository;
 
-public class BookMarkRepository {
+import com.talkit.app.domain.community.entity.Bookmark;
+import com.talkit.app.domain.community.entity.Community;
+import com.talkit.app.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+
+    Optional<Bookmark> findByUserAndCommunity(User user, Community community);
+
+    List<Bookmark> findAllByUser(User user);
+
+    boolean existsByCommunityIdAndUserId(Long communityId, Long userId);
 
 }

--- a/src/main/java/com/talkit/app/domain/community/bookMark/service/BookmarkService.java
+++ b/src/main/java/com/talkit/app/domain/community/bookMark/service/BookmarkService.java
@@ -1,0 +1,58 @@
+package com.talkit.app.domain.community.bookmark.service;
+
+import com.talkit.app.domain.community.base.repository.CommunityRepository;
+import com.talkit.app.domain.community.bookmark.dto.BookmarkResponseDto;
+import com.talkit.app.domain.community.bookmark.repository.BookmarkRepository;
+import com.talkit.app.domain.community.entity.Bookmark;
+import com.talkit.app.domain.community.entity.Community;
+import com.talkit.app.domain.user.entity.User;
+import com.talkit.app.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.talkit.app.global.exception.ExceptionType.NOT_FOUND_COMMUNITY;
+import static com.talkit.app.global.exception.ExceptionType.NOT_FOUND_USER;
+
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Service
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final CommunityRepository communityRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public boolean toggleBookMark(Long communityId, Long userId) {
+        Community community = communityRepository.findById(communityId)
+                .orElseThrow(NOT_FOUND_COMMUNITY::of);
+        User user = userRepository.findById(userId)
+                .orElseThrow(NOT_FOUND_USER::of);
+
+        return bookmarkRepository.findByUserAndCommunity(user, community)
+                .map(bookMark -> {
+                    bookmarkRepository.delete(bookMark);
+                    return false;
+                })
+                .orElseGet(() -> {
+                    bookmarkRepository.save(Bookmark.of(user, community));
+                    return true;
+                });
+    }
+
+    public List<BookmarkResponseDto> getMyBookMarks(Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(NOT_FOUND_USER::of);
+
+        return bookmarkRepository.findAllByUser(user).stream()
+                .sorted((b1, b2) -> b2.getCreatedAt().compareTo(b1.getCreatedAt()))
+                .map(BookmarkResponseDto::of)
+                .toList();
+    }
+
+    public boolean isBookmarked(Long communityId, Long userId) {
+        return bookmarkRepository.existsByCommunityIdAndUserId(communityId, userId);
+    }
+}

--- a/src/main/java/com/talkit/app/domain/community/entity/BookMark.java
+++ b/src/main/java/com/talkit/app/domain/community/entity/BookMark.java
@@ -1,5 +1,44 @@
 package com.talkit.app.domain.community.entity;
 
-public class BookMark {
+import com.talkit.app.domain.user.entity.User;
+import com.talkit.app.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(
+        name = "community_bookmark",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "community_id"})
+        }
+)
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Bookmark extends BaseEntity {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "community_id", nullable = false)
+    private Community community;
+
+    public static Bookmark of(User user, Community community) {
+        return Bookmark.builder()
+                .user(user)
+                .community(community)
+                .build();
+    }
 
 }

--- a/src/main/java/com/talkit/app/domain/community/entity/Community.java
+++ b/src/main/java/com/talkit/app/domain/community/entity/Community.java
@@ -48,6 +48,9 @@ public class Community extends BaseEntity {
     @OneToMany(mappedBy = "community", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CommunityLike> communityLikeList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "community", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Bookmark> bookmarkList = new ArrayList<>();
+
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(name = "community_tags", joinColumns = @JoinColumn(name = "community_id"))
     @Column(name = "tag_name")

--- a/src/main/java/com/talkit/app/domain/community/like/controller/CommunityLikeController.java
+++ b/src/main/java/com/talkit/app/domain/community/like/controller/CommunityLikeController.java
@@ -40,7 +40,7 @@ public class CommunityLikeController {
     @Operation(summary = "좋아요 상태 변경(Toggle)")
     @AuthenticatedUser
     @PostMapping("/toggle")
-    public ResponseDto<CommunityLikeResponseDto> toggleRecipeLike(@PathVariable Long id) {
+    public ResponseDto<CommunityLikeResponseDto> toggleCommunityLike(@PathVariable Long id) {
         Long userId = AuthenticationHolder.getCurrentUserId();
         return ResponseDto.of(communityLikeService.toggleLike(id, userId));
     }

--- a/src/main/java/com/talkit/app/domain/community/like/service/CommunityLikeService.java
+++ b/src/main/java/com/talkit/app/domain/community/like/service/CommunityLikeService.java
@@ -1,5 +1,6 @@
 package com.talkit.app.domain.community.like.service;
 
+import com.talkit.app.domain.community.base.repository.CommunityRepository;
 import com.talkit.app.domain.community.base.service.CommunityService;
 import com.talkit.app.domain.community.entity.Community;
 import com.talkit.app.domain.community.like.dto.CommunityLikeResponseDto;
@@ -7,10 +8,15 @@ import com.talkit.app.domain.community.entity.CommunityLike;
 import com.talkit.app.domain.community.like.repository.CommunityLikeRepository;
 import com.talkit.app.domain.user.entity.User;
 import com.talkit.app.domain.user.service.UserService;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static com.talkit.app.global.exception.ExceptionType.NOT_FOUND_COMMUNITY;
 
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
@@ -18,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommunityLikeService {
 
     private final CommunityLikeRepository communityLikeRepository;
-    private final CommunityService communityService;
+    private final CommunityRepository communityRepository;
     private final UserService userService;
 
     public boolean isLiked(Long id, Long userId) {
@@ -37,10 +43,17 @@ public class CommunityLikeService {
             communityLikeRepository.delete(like.get());
         } else {
             User user = userService.findUserById(userId);
-            Community community = communityService.getCommunity(communityId);
+            Community community = communityRepository.findById(communityId)
+                    .orElseThrow(NOT_FOUND_COMMUNITY::of);
             communityLikeRepository.save(CommunityLike.of(user, community));
         }
         return CommunityLikeResponseDto.of(communityId);
+    }
+
+    public List<CommunityLike> getCommunityLikesByUserId(Long userId) {
+        return userId.equals(User.ANONYMOUS_USER_ID)
+                ? new ArrayList<>()
+                : communityLikeRepository.findCommunityLikesByUserId(userId);
     }
 
 }


### PR DESCRIPTION
## 📝 PR 내용

### 🚀 주요 변경 사항
이번 PR에서는 **북마크 기능**을 게시글 상세 조회에 연동하고, 기존 좋아요 서비스에서 발생하던 **순환 참조 문제**를 해결했습니다.

#### 1. 북마크(Bookmark) 기능 연동
* **상세 조회 데이터 확장**: `CommunityResponseDto`에 `isBookmarked` 필드를 추가하여 게시글 상세 조회 시 사용자의 북마크 여부를 확인할 수 있도록 개선했습니다.
* **서비스 로직 반영**: `CommunityService`의 상세 조회 로직에서 `BookmarkService`를 호출하여 실시간 북마크 상태를 주입합니다.

#### 2. 서비스 구조 개선 (순환 참조 해결)
* **의존성 전파 차단**: `CommunityLikeService`가 `CommunityService`를 참조하던 구조를 `CommunityRepository` 직접 참조 방식으로 변경하여 애플리케이션 시작 시 발생하던 **Circular Dependency** 에러를 해결했습니다.
* **오타 및 명명 규칙 정리**:
    * `CommunityLikeController`의 잘못된 메서드명(`toggleRecipeLike`)을 도메인에 맞게 수정했습니다.
    * `CommunityController` 내 메서드명들을 일관성 있게 정리했습니다. (`communityCreate` → `createCommunity` 등)

<img width="100%" height="100%" alt="image" src="https://github.com/user-attachments/assets/22b8f49d-e78a-4159-a57d-8b7b52b74f51" />
