### PR TITLE
[ feat ] : 채팅에서 공통으로 사용될 뱃지 관련 폴더 구조 세팅

### DIFF
--- a/src/main/java/com/talkit/app/domain/chatting/badge/controller/BadgeController.java
+++ b/src/main/java/com/talkit/app/domain/chatting/badge/controller/BadgeController.java
@@ -1,0 +1,13 @@
+package com.talkit.app.domain.chatting.badge.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@Tag(name = "채팅 공통 - 뱃지 달성 관련 API", description = "채팅 공통 - 뱃지 달성 관련 API")
+@RequestMapping("/api/chatting-badge")
+@RestController
+public class BadgeController {
+}

--- a/src/main/java/com/talkit/app/domain/chatting/badge/dto/BadgeRequestDto.java
+++ b/src/main/java/com/talkit/app/domain/chatting/badge/dto/BadgeRequestDto.java
@@ -1,0 +1,4 @@
+package com.talkit.app.domain.chatting.badge.dto;
+
+public record BadgeRequestDto() {
+}

--- a/src/main/java/com/talkit/app/domain/chatting/badge/dto/BadgeResponseDto.java
+++ b/src/main/java/com/talkit/app/domain/chatting/badge/dto/BadgeResponseDto.java
@@ -1,0 +1,7 @@
+package com.talkit.app.domain.chatting.badge.dto;
+
+import lombok.Builder;
+
+@Builder
+public record BadgeResponseDto() {
+}

--- a/src/main/java/com/talkit/app/domain/chatting/badge/entity/Badge.java
+++ b/src/main/java/com/talkit/app/domain/chatting/badge/entity/Badge.java
@@ -1,0 +1,21 @@
+package com.talkit.app.domain.chatting.badge.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "badge")
+@Getter
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Badge {
+
+    @Id
+    @Column(name = "id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}

--- a/src/main/java/com/talkit/app/domain/chatting/badge/repository/BadgeRepository.java
+++ b/src/main/java/com/talkit/app/domain/chatting/badge/repository/BadgeRepository.java
@@ -1,0 +1,9 @@
+package com.talkit.app.domain.chatting.badge.repository;
+
+import com.talkit.app.domain.chatting.badge.entity.Badge;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BadgeRepository extends JpaRepository<Badge, Long> {
+}

--- a/src/main/java/com/talkit/app/domain/chatting/badge/service/BadgeService.java
+++ b/src/main/java/com/talkit/app/domain/chatting/badge/service/BadgeService.java
@@ -1,0 +1,7 @@
+package com.talkit.app.domain.chatting.badge.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class BadgeService {
+}


### PR DESCRIPTION
### 작업 내용
- 채팅에서 공통으로 사용될 뱃지 관련 폴더 구조 세팅



#### 대표 뱃지 예시 (enum으로 넣어야 할 것 들)

- 사용자/AI 가 피드백을 주는 것들
    - 🌤️ **날씨 뱃지** → 날씨 키워드 10회 사용
    - ⚾ **스포츠 뱃지 →** 스포츠 위주의 대화
    - 🎮 **게임 뱃지** → 게임 위주의 대화
    - 🐈 동물 뱃지 → 동물 키워드를 자주 쓰는 사용자
    - 🪴 식물 뱃지 → 식물 키워드를 자주 쓰는 사용자
    - 🎤 아이돌 뱃지 → 아이돌 키워드를 자주 쓰는 사용자
    - 🎞️ 영화 뱃지 → 영화 키워드를 자주 쓰는 사용자
    - 📺 드라마 뱃지 → 드라마 키워드를 자주 쓰는 사용자
    - 🌏**여행 뱃지** → 지역·나라·장소 관련 키워드를 자주 쓰는 사용자
    - 🐛**공부벌레 뱃지** → 학습 위주의 대화
    - 🍚  **먹방 뱃지** → 음식 키워드 누적

- **🤣유머 뱃지** → 농담, 웃음을 자주 유발하는 사용자
- **🤐침묵 뱃지** → 대화 중 발화 비율이 지나치게 낮은 사용자
- **🔄️되풀이 뱃지** → 같은 말만 반복하는 사용자
- 🕵️ **탐정 뱃지** → 질문을 유난히 많이 던지는 사용자
- 🥱 **하품 뱃지** → “ㅋㅋ”, “ㅇㅇ” 같은 무성의한 반응만 반복하는 사용자

- 서버에서 조회해야 하는 것들
    - **🌱 새싹 뱃지** → 처음으로 대화 10회 이상 달성한 사용자
    - 👑 **대화왕 뱃지** → n회 이상 대화
    - 💬 **긴 말 잘해요** (20자 이상 지속)
    - 🧡 **따뜻한 사람** (긍정 피드백 다수)
    - **🧊 얼음 뱃지** → (부정 피드백 다수)
    - ✅ **대화 루틴러** (5일 연속 말잇기)
    - **🦉야행성 뱃지 →** 밤 시간대에 대화를 많이 하는 사용자
    - 🐦 **아침형 뱃지** → 아침 시간대에 대화를 많이 하는 사용자
    - 🔥**열정 뱃지**→ n일 연속 사용